### PR TITLE
python2.7 support

### DIFF
--- a/undine/__init__.py
+++ b/undine/__init__.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 
 __author__="Mike Shultz <mike@votesmart.org>"
 __copyright__="Copyright (c) 2017 Vote Smart"
-__version__="0.0.2"
+__version__="0.0.3"
 
 import os, sys, argparse, socket, fasteners
 from subprocess import Popen, PIPE


### PR DESCRIPTION
Made some changes so python 2.7 is supported.  This should allow the use of most systems' default python.

Also included in this PR, is the addition of `--remote-path` support, which might be useful for you with rsync.net.  The default borg they give you is 0.x, but specifying `--remote-path=borg1` allows you to use borg 1.x.

I have some more changes in my master branch, as well, but I'll leave those out of this PR.